### PR TITLE
Implemented API route to return a specific skill

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,8 +93,19 @@ def skill():
         The skill(s) as a JSON object, or an error message.
     '''
     if request.method == 'GET':
-        return jsonify({})
+        skills = data.get('skill', [])
+        index = request.args.get('index')
 
+        # Returns a specific skill if the index was specified by the user
+        if index is not None:
+            try:
+                index = int(index)
+                return jsonify(skills[index])
+            except:
+                return jsonify({'error': 'skill not found'}), 404
+
+        return jsonify({})
+        
     if request.method == 'POST':
         return jsonify({})
 

--- a/app.py
+++ b/app.py
@@ -100,8 +100,10 @@ def skill():
         if index is not None:
             try:
                 index = int(index)
-                return jsonify(skills[index])
-            except:
+                if 0 <= index < len(skills):
+                    return jsonify(skills[index])    
+                return jsonify({'error': 'skill not found'}), 404
+            except ValueError:
                 return jsonify({'error': 'skill not found'}), 404
 
         return jsonify({})


### PR DESCRIPTION
## Description
Updated the `/resume/skill` endpoint for GET requests to accept index values and return a single experience.

## Issue
This request closes issue #14.

## Testing
An example GET request for `/resume/skill?index=value` will return a valid skill in JSON form if `value` is numeric and within bounds. There are two examples below.

A GET request for `/resume/skill?index=0` will succeed:
```json
{
  "logo":"example-logo.png",
  "name":"Python",
  "proficiency":"1-2 Years"
}
```

A GET request for `/resume/skill?index=1` will fail and return a generic error:
```json
{
  "error":"skill not found"
}
```