### PR TITLE
Implement POST resume/experience endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,7 @@ def experience():
     json
         The experience(s) as a JSON object, or an error message.
     '''
+    response = None
     if request.method == 'GET':
         index = request.args.get('index')
         experiences = data.get('experience',[])
@@ -62,17 +63,30 @@ def experience():
             try:
                 index = int(index)
                 if 0 <= index < len(experiences):
-                    return jsonify(experiences[index])
-                return jsonify({'error':'Experience does not exist'}), 404
+                    response = jsonify(experiences[index])
+                else:
+                    response = jsonify({'error':'Experience does not exist'}), 404
             except ValueError:
-                return jsonify({'error':'Experience does not exist'}), 404
-        return jsonify(experiences)
+                response = jsonify({'error':'Experience does not exist'}), 404
+        else:
+            response = jsonify(experiences)
 
     if request.method == 'POST':
-        return jsonify({})
-
-    return jsonify({})
-
+        required_fields = ['title','company','start_date','end_date','description','logo']
+        if not request.json:
+            response = jsonify({'error':'Filed Creating Experience'}), 400
+        else:
+            missing_fields = [field.capitalize() for field in required_fields
+                               if field not in request.json]
+            if len(missing_fields) > 0:
+                response = jsonify({'error':f'Missing Field: {missing_fields[0]}'}), 400
+            else:
+                experiences = data.get('experience',[])
+                experience_id = len(experiences)
+                experiences.append(request.json)
+                data['experience'] = experiences
+                response = jsonify({'id':experience_id})
+    return response
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():
     '''


### PR DESCRIPTION
## Description 

- Implemented POST `resume/experience` endpoint. 
- Refactored the code to avoid using too many "return" as the lint warns

## How to Test
- Make a post request to `resume/experience` with `{"title": "Software Developer",
    "start_date": "2020-1-1",
    "company": "xyz company",
    "end_date": "2021-4-2",
    "description": "Worked as a software developer",
    "logo": "https://sampleimage.xyz"}`. It will return the id of the newly created experience.

test_pytest.py passed for the experience section

## Related Issue 
closes #22

