### PR TITLE
Implemented existing skills & created corresponding test case

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,7 @@ def education():
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route('/resume/skill', methods=['GET', 'POST', 'PUT'])
 def skill():
     '''
     Route for creating a new skill and fetching all skills.
@@ -108,5 +108,25 @@ def skill():
         
     if request.method == 'POST':
         return jsonify({})
+
+    if request.method == 'PUT':
+        skills = data.get('skill',[])
+        index = request.args.get('index')
+        if index is None or request.json is None:
+            return jsonify({'error:': 'Skill does not exist'}), 404
+        try:
+            index = int(index)
+            if index < 0 or index >= len(skills):
+                return jsonify({'error:': 'Skill does not exist'}), 404
+            skill_dict = request.json
+            updated_skill = {'name': skill_dict['name'],
+                                  'proficiency': skill_dict['proficiency'],
+                                  'logo': skill_dict['logo']}
+            skills[index] = updated_skill
+            data['skill'] = skills
+            save_data('data.json', data)
+            return jsonify(updated_skill), 200
+        except (ValueError, KeyError, TypeError):
+            return jsonify({'error:': 'Skill does not exist'}), 404
 
     return jsonify({})

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -108,3 +108,19 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+def test_skill_edit():
+    '''
+    Edit an existing skill and then obtain the skill at that index. 
+    
+    Check that it returns the updated skill at that index
+    '''
+    example_skill = {
+        "name": "JavaScript",
+        "proficiency": "2-4 years",
+        "logo": "example-logo.png"
+    }
+
+    app.test_client().put('/resume/skill?index=0', json=example_skill)
+    response = app.test_client().get('/resume/skill?index=0')
+    assert response.json == example_skill


### PR DESCRIPTION
## Summary
Added and updated the `/resume/skill` endpoint for PUT requests to accept a JSON and index to edit existing skills. On success, the new skill is returned in JSON format, and both `data` in memory and `data.json` on disk are updated.

## Issue
This request closes issue #6.

## Testing
An example PUT request for `/resume/skill?index=value` will succeed if a valid JSON is provided and `value` is numeric and within bounds. The provided test case `test_skill_edit()` in `test_pytest.py` calls this endpoint with index 0 and a new skill. It then validates its success by comparing it with a GET request at the same index.

## Concerns
This implementation does not use the serialization class we discussed earlier as the issue has not yet been resolved. Similarly, `index` is obtained via query (not URL) parameters, which is another concern our team has discussed. Furthermore, a valid input JSON is one that simply includes all attributes found in the `Skill` class, so other dictionary entries are valid, but ignored.
