### PR TITLE
Implemented DELETE for existing skills

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,7 @@ def education():
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route('/resume/skill', methods=['GET', 'POST', 'DELETE'])
 def skill():
     '''
     Route for creating a new skill and fetching all skills.
@@ -108,5 +108,20 @@ def skill():
         
     if request.method == 'POST':
         return jsonify({})
+    
+    if request.method == 'DELETE':
+        index = request.args.get('index')
+        skills = data.get('skill',[])
+        if index is None:
+            return jsonify({'error':'Skill does not exist'}), 404
+        try:
+            index = int(index)
+            if index < 0 or index >= len(skills):
+                return jsonify({'error:': 'Skill does not exist'}), 404
+            deleted_skill = skills.pop(index)
+            save_data('data.json', data)
+            return jsonify(deleted_skill), 200
+        except ValueError:
+            return jsonify({'error:': 'Skill does not exist'}), 404
 
     return jsonify({})

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -108,3 +108,15 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+def test_skill_delete():
+    '''
+    Delete an existing skill.
+    
+    Check that the skill at that index is either invalid or different.
+    '''
+    example_skill = app.test_client().get('/resume/skill?index=0').json
+
+    app.test_client().delete('/resume/skill?index=0')
+    response = app.test_client().get('/resume/skill?index=0')
+    assert 'error' in response.json or response.json == example_skill


### PR DESCRIPTION
## Summary
Added and updated the `/resume/skill` endpoint for DELETE requests to remove existing skills. On success, the erased skill is returned in JSON format, and both `data` in memory and `data.json` on disk are updated.

## Issue
This request closes issue #3.

## Testing
An example DELETE request for `/resume/skill?index=value` will succeed if a valid JSON is provided and `value` is numeric and within bounds. The provided test case `test_skill_delete()` in `test_pytest.py` calls this endpoint with index 0. It then validates the removal by calling a GET request at the same index, ensuring an error or a different skill is returned.

## Concerns
This implementation does not use the serialization class we discussed earlier as the issue has not yet been resolved. Similarly, `index` is obtained via query (not URL) parameters, which is another concern our team has discussed. Lastly, there can be mismatches between the `id` attribute and the actual index of a given skill; deleting a skill will decrement the indices of all skills in front, but not their ids. As such, the `id` of different skills can be identical under certain conditions, and may generally lead to problems.